### PR TITLE
Mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ it, simply add the following line to your Podfile:
 
 or
 
-    pod "FSHelper+ObjectiveC"
+    pod "FSHelper"


### PR DESCRIPTION
If we try to add Helpers for Objective C we should use `pod `FSHelper`` instead of `pod `FSHelper+ObjectiveC``
otherwise we get error:
`[!] Unable to find a specification for `FSHelper+ObjectiveC``
